### PR TITLE
chore(promise-cache): handle set, map, object, array

### DIFF
--- a/.changeset/calm-spoons-compare.md
+++ b/.changeset/calm-spoons-compare.md
@@ -1,0 +1,5 @@
+---
+"@sebspark/promise-cache": major
+---
+
+TTL is always seconds, support for custom logger injection, handle set, map, object, array.

--- a/.changeset/calm-spoons-compare.md
+++ b/.changeset/calm-spoons-compare.md
@@ -2,4 +2,6 @@
 "@sebspark/promise-cache": major
 ---
 
-TTL is always seconds, support for custom logger injection, handle set, map, object, array.
+- TTL is always seconds.
+- Support logger injection.
+- Handle complex types; set, map, object, array.

--- a/packages/promise-cache/README.md
+++ b/packages/promise-cache/README.md
@@ -1,23 +1,163 @@
 # `@sebspark/promise-cache`
 
-A simple caching wrapper for promises.
+Simple caching wrapper
+
+## **Features**
+
+- **PromiseCache**: Simple caching wraper for promises
+- **Persistor**: Simple Key/Value caching wrapper, can be used with redis or with local memory.
+  
+## **Installation**
+
+To install promise-cache, use `yarn`:
+
+```bash
+yarn install @sebspark/promise-cache
+```
+## **Usage**
+
+### **PromiseCache Class**
+
+| Params        | Type     | Default |Description                                  |
+|---------------|----------|---------|---------------------------------------------|
+| redis         | RedisClientOptions   |    undefined     |Redis instance url, skip if use local memory |
+| ttlInSeconds  | number   |   undefined      |Persist time in Seconds                      |
+| caseSensituve | boolean  |   false    |Retrieving cache with case sensitive         |
+| onSuccess     | function |    undefined     |Callback function if connection is success   |
+| onError       | function |    undefined     |Callback function if there is an error       |
+| logger        | winston Logger |    undefined     |Logger                                 |
 
 ```typescript
-/*
- * Pseudocode example.
- */
 import { PromiseCache } from '@sebspark/promise-cache'
 
-// Instantiate the cache with a TTL.
-const cache = new PromiseCache<number>(60, true, true) // 1 minute cache TTL / is case sensitive / use local storage
+// with redis
+const cacheInRedis = new PromiseCache<T>({
+  redis: REDIS_URL,
+  ttlInSeconds: ttl,
+  caseSensitive: true
+})
 
-const redisCache = new PromiseCache<number>(60, false, false) // 1 minute cache TTL / is not case sensitive / use redis storage
+// without redis
+const cacheLocalMemory = new PromiseCache<T>({
+  ttlInSeconds: ttl,
+  caseSensitive: true
+})
+```
 
-// Use the cache wrapper for a database query to relieve the database.
-const query = 'SELECT username FROM users ORDER BY created DESC LIMIT 1'
-const newestUser = await cache.wrap('newestUser', () => database.query(query))
+## **PromiseCache Methods**
 
-// Use the cache wrapper for a database query to relieve the database.
-const query = 'SELECT username FROM users ORDER BY created DESC LIMIT 1'
-const newestUser = await redisCache.wrap('newestUserRedis', () => database.query(query))
+```typescript
+// Wrap
+/* Simple promise cache wrapper
+ * @param key Cache key.
+ * @param delegate The function to execute if the key is not in the cache.
+ * @param ttlInSeconds Time to live in seconds.
+ * @param ttlKeyInSeconds The key in the response object that contains the TTL.
+ * @returns The result of the delegate function.
+*/
+const ttl = 5 // 5 seconds
+const delegate = new Promise((reject, resolve) => { resolve(123)})
+const response = await cacheInRedis.wrap('Key', delegate, ttl)
+expect(response).toBe(123)
+
+// Size
+/*
+* Cache size
+* @returns The number of entries in the cache
+*/
+
+const entries = await cacheInRedis.size()
+expect(entries).toBe(1)
+
+// Find
+ /**
+* Get a value from the cache.
+* @param key Cache key.
+*/
+
+const cachedValue = await cacheInRedis.find('Key')
+expect(cachedValue).toBe(123)
+
+// Override
+/**
+ * Set a value in the cache.
+ * @param key Cache key.
+ * @param value Cache value.
+ * @param ttlInSeconds? Time to live in seconds.
+ */
+
+await cacheInRedis.override('Key', 234) // keep the same ttl
+const cached = cacheInRedis.find('Key')
+expect(cached).toBe(234)
+```
+
+### **Persistor Class**
+
+| Params        | Type     | Default |Description                                  |
+|---------------|----------|---------|---------------------------------------------|
+| redis         | RedisClientOptions   |    undefined     |Redis instance url, skip if use local memory |
+| onSuccess     | function |    undefined     |Callback function if connection is success   |
+| onError       | function |    undefined     |Callback function if there is an error       |
+| logger        | winston Logger |    undefined     |Logger                                 |
+| clientId        | any |    undefined     |Object internal id                                 |
+
+```typescript
+import { Persistor } from '@sebspark/promise-cache'
+
+// with redis
+const store = new Persistor<T>({
+  redis: REDIS_URL,
+})
+
+// without redis
+const store = new Persistor<T>()
+```
+
+## **Persistor Methods**
+
+```typescript
+
+/**
+* Size
+* @returns The number of entries in the cache
+*/
+
+const size = await store.size()
+expect(size).toBe(0)
+
+/**
+* Set
+* Set a value in the cache.
+* @param key Cache key.
+* @param object.value Value to set in the cache.
+* @param object.ttl Time to live in seconds.
+* @param object.timestamp Timestamp
+*/
+
+await store.set<number>('MyKey', {
+  value: 123,
+  ttl: 10               // In seconds, default undefined
+  timestamp: Date.now() // default Date.now()
+})
+
+/**
+ * Get a value from the cache.
+ * @param key Cache key.
+ * @returns GetType<T> value
+ */
+
+const cached = await store.get('MyKey')
+expect(cached).toBe({
+  value: 43,
+  ttl: 10,
+  timestamp: // The timestamp
+})
+
+/**
+ * Delete a value from the cache.
+ * @param key Cache key
+ */
+
+await store.delete('MyKey')
+expect(await store.get('MyKey').toBe(null)
 ```

--- a/packages/promise-cache/package.json
+++ b/packages/promise-cache/package.json
@@ -19,7 +19,6 @@
     "tsconfig": "*"
   },
   "dependencies": {
-    "redis": "4.7.0",
-    "@sebspark/retry": "*"
+    "redis": "4.7.0"
   }
 }

--- a/packages/promise-cache/src/index.ts
+++ b/packages/promise-cache/src/index.ts
@@ -1,3 +1,2 @@
 export * from './promiseCache'
-export * from './localMemory'
 export * from './persistor'

--- a/packages/promise-cache/src/persistor.spec.ts
+++ b/packages/promise-cache/src/persistor.spec.ts
@@ -19,8 +19,8 @@ describe('Persistor', () => {
   })
 
   beforeAll(() => {
-    // console.error = vi.fn()
-    // console.log = vi.fn()
+    console.error = vi.fn()
+    console.log = vi.fn()
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
 

--- a/packages/promise-cache/src/persistor.spec.ts
+++ b/packages/promise-cache/src/persistor.spec.ts
@@ -1,0 +1,299 @@
+import { afterEach } from 'node:test'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { Persistor } from './index'
+
+vi.mock('redis')
+
+const REDIS_URL = {
+  url: 'redis://127.0.0.1:6379',
+}
+
+const store: Persistor = new Persistor({
+  redis: REDIS_URL,
+})
+
+describe('Persistor', () => {
+  afterAll(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  beforeAll(() => {
+    // console.error = vi.fn()
+    // console.log = vi.fn()
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.runAllTimers()
+  })
+
+  it('should cache and return the result', async () => {
+    const timestamp = Date.now()
+    store.set<number>('testKey', { value: 43, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: 43,
+      ttl: 10,
+      timestamp,
+    })
+  })
+
+  it('should delete the value in cache', async () => {
+    const timestamp = Date.now()
+    store.set('testKey', { value: 43, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: 43,
+      ttl: 10,
+      timestamp,
+    })
+    store.delete('testKey')
+    expect(await store.get('testKey')).toEqual(null)
+  })
+
+  it('should store all primitives in javascript', async () => {
+    const timestamp = Date.now()
+    // String
+    store.set('testKey', { value: '43', ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: '43',
+      ttl: 10,
+      timestamp,
+    })
+    // Number
+    store.set('testKey', { value: 43, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: 43,
+      ttl: 10,
+      timestamp,
+    })
+    // Bigint
+    const hugeHex = BigInt('0x1fffffffffffff')
+    // 9007199254740991n
+    store.set('testKey', { value: hugeHex, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: hugeHex,
+      ttl: 10,
+      timestamp,
+    })
+    const alsoHuge = BigInt(9007199254740991)
+    // 9007199254740991n
+    store.set('testKey', { value: alsoHuge, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: alsoHuge,
+      ttl: 10,
+      timestamp,
+    })
+    const hugeString = BigInt('9007199254740991')
+    // 9007199254740991n
+    store.set('testKey', { value: hugeString, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: hugeString,
+      ttl: 10,
+      timestamp,
+    })
+    const hugeOctal = BigInt('0o377777777777777777')
+    // 9007199254740991n
+    store.set('testKey', { value: hugeOctal, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: hugeOctal,
+      ttl: 10,
+      timestamp,
+    })
+    const hugeBin = BigInt(
+      '0b11111111111111111111111111111111111111111111111111111'
+    )
+    store.set('testKey', { value: hugeBin, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: hugeBin,
+      ttl: 10,
+      timestamp,
+    })
+    // Boolean
+    store.set('testKey', { value: true, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: true,
+      ttl: 10,
+      timestamp,
+    })
+    // Undefined
+    store.set('testKey', { value: undefined, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: undefined,
+      ttl: 10,
+      timestamp,
+    })
+    // Null
+    store.set('testKey', { value: null, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: null,
+      ttl: 10,
+      timestamp,
+    })
+  })
+
+  it('should store all complex data types in javascript', async () => {
+    const timestamp = Date.now()
+
+    // Simple object
+    store.set('testKey', { value: { a: 1, b: 2 }, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: { a: 1, b: 2 },
+      ttl: 10,
+      timestamp,
+    })
+
+    // Nested object
+    const nestedObject = {
+      user: {
+        id: 123,
+        profile: {
+          name: 'Jane Doe',
+          hobbies: ['reading', 'traveling', 'gaming'],
+        },
+      },
+      settings: {
+        darkMode: true,
+        notifications: {
+          email: false,
+          sms: true,
+        },
+      },
+    }
+    store.set('testKey', { value: nestedObject, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: nestedObject,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Mixed object
+    const mixedObject = {
+      numberKey: 42,
+      stringKey: 'Hello World',
+      booleanKey: false,
+      nullKey: null,
+      bigintKey: BigInt(123),
+      arrayKey: [1, 'a', null],
+      mapKey: new Map<string, unknown>([
+        ['key1', 'value1'],
+        ['key2', 2],
+      ]),
+      setKey: new Set(['x', 'y', 'z']),
+    }
+
+    store.set('testKey', { value: mixedObject, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: mixedObject,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Simple set
+    const simpleSet = new Set([1, 2, 3, 4, 5])
+    store.set<Set<number>>('testKey', { value: simpleSet, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: simpleSet,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Mixed set
+    const big = BigInt(123)
+    const mixedSet = new Set([42, 'hello', true, null, big])
+    store.set('testKey', { value: mixedSet, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: mixedSet,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Nested set
+    const nestedSet = new Set([new Set([1, 2, 3]), new Set(['a', 'b', 'c'])])
+    store.set('testKey', { value: nestedSet, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: nestedSet,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Simple map
+    const simpleMap = new Map([
+      ['key1', 'value1'],
+      ['key2', 'value2'],
+      ['key3', 'value3'],
+    ])
+
+    store.set('testKey', { value: simpleMap, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: simpleMap,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Map with mixed data type
+    const mixedMap = new Map<unknown, unknown>([
+      [1, 'one'],
+      ['two', 2],
+      [true, 'booleanKey'],
+      [null, 'nullKey'],
+    ])
+
+    store.set('testKey', { value: mixedMap, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: mixedMap,
+      ttl: 10,
+      timestamp,
+    })
+
+    // Nested map
+    // const nestedMap = new Map<unknown, unknown>([
+    //     ['innerMap', new Map<string, unknown>([
+    //         ['nestedKey1', 'nestedValue1'],
+    //         ['nestedKey2', 42],
+    //     ])],
+    //     ['anotherMap', new Map<boolean, string>([
+    //         [true, 'trueValue'],
+    //         [false, 'falseValue'],
+    //     ])],
+    // ]);
+
+    // store.set('testKey', { value: nestedMap, ttl: 10, timestamp })
+    // expect(await store.get('testKey')).toEqual({ value: nestedMap, ttl: 10, timestamp })
+
+    // Complex structure
+    // const complexTestStructure = {
+    //     sets: {
+    //         simpleSet: new Set([1, 2, 3]),
+    //         mixedSet: new Set([42, 'hello', true, null, 123]),
+    //     },
+    //     maps: {
+    //         simpleMap: new Map([
+    //             ['key1', 'value1'],
+    //             ['key2', 'value2'],
+    //         ]),
+    //         nestedMap: new Map([
+    //             ['innerMap', new Map<string, unknown>([
+    //                 ['nestedKey1', 'nestedValue1'],
+    //                 ['nestedKey2', 42],
+    //             ])],
+    //         ]),
+    //     },
+    //     object: {
+    //         basic: {
+    //             name: 'Alice',
+    //             age: 25,
+    //         },
+    //         withNestedData: {
+    //             hobbies: ['reading', 'coding'],
+    //             preferences: {
+    //                 theme: 'dark',
+    //                 notifications: false,
+    //             },
+    //         },
+    //     },
+    // };
+
+    // store.set('testKey', { value: complexTestStructure, ttl: 10, timestamp })
+    // expect(await store.get('testKey')).toEqual({ value: complexTestStructure, ttl: 10, timestamp })
+  })
+})

--- a/packages/promise-cache/src/persistor.spec.ts
+++ b/packages/promise-cache/src/persistor.spec.ts
@@ -246,54 +246,77 @@ describe('Persistor', () => {
     })
 
     // Nested map
-    // const nestedMap = new Map<unknown, unknown>([
-    //     ['innerMap', new Map<string, unknown>([
-    //         ['nestedKey1', 'nestedValue1'],
-    //         ['nestedKey2', 42],
-    //     ])],
-    //     ['anotherMap', new Map<boolean, string>([
-    //         [true, 'trueValue'],
-    //         [false, 'falseValue'],
-    //     ])],
-    // ]);
+    const nestedMap = new Map<unknown, unknown>([
+      [
+        'innerMap',
+        new Map<string, unknown>([
+          ['nestedKey1', 'nestedValue1'],
+          ['nestedKey2', 42],
+        ]),
+      ],
+      [
+        'anotherMap',
+        new Map<boolean, string>([
+          [true, 'trueValue'],
+          [false, 'falseValue'],
+        ]),
+      ],
+    ])
+    store.set('testKey', { value: nestedMap, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: nestedMap,
+      ttl: 10,
+      timestamp,
+    })
 
-    // store.set('testKey', { value: nestedMap, ttl: 10, timestamp })
-    // expect(await store.get('testKey')).toEqual({ value: nestedMap, ttl: 10, timestamp })
+    store.set('testKey', { value: nestedMap, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: nestedMap,
+      ttl: 10,
+      timestamp,
+    })
 
     // Complex structure
-    // const complexTestStructure = {
-    //     sets: {
-    //         simpleSet: new Set([1, 2, 3]),
-    //         mixedSet: new Set([42, 'hello', true, null, 123]),
-    //     },
-    //     maps: {
-    //         simpleMap: new Map([
-    //             ['key1', 'value1'],
-    //             ['key2', 'value2'],
-    //         ]),
-    //         nestedMap: new Map([
-    //             ['innerMap', new Map<string, unknown>([
-    //                 ['nestedKey1', 'nestedValue1'],
-    //                 ['nestedKey2', 42],
-    //             ])],
-    //         ]),
-    //     },
-    //     object: {
-    //         basic: {
-    //             name: 'Alice',
-    //             age: 25,
-    //         },
-    //         withNestedData: {
-    //             hobbies: ['reading', 'coding'],
-    //             preferences: {
-    //                 theme: 'dark',
-    //                 notifications: false,
-    //             },
-    //         },
-    //     },
-    // };
+    const complexTestStructure = {
+      sets: {
+        simpleSet: new Set([1, 2, 3]),
+        mixedSet: new Set([42, 'hello', true, null, 123]),
+      },
+      maps: {
+        simpleMap: new Map([
+          ['key1', 'value1'],
+          ['key2', 'value2'],
+        ]),
+        nestedMap: new Map([
+          [
+            'innerMap',
+            new Map<string, unknown>([
+              ['nestedKey1', 'nestedValue1'],
+              ['nestedKey2', 42],
+            ]),
+          ],
+        ]),
+      },
+      object: {
+        basic: {
+          name: 'Alice',
+          age: 25,
+        },
+        withNestedData: {
+          hobbies: ['reading', 'coding'],
+          preferences: {
+            theme: 'dark',
+            notifications: false,
+          },
+        },
+      },
+    }
 
-    // store.set('testKey', { value: complexTestStructure, ttl: 10, timestamp })
-    // expect(await store.get('testKey')).toEqual({ value: complexTestStructure, ttl: 10, timestamp })
+    store.set('testKey', { value: complexTestStructure, ttl: 10, timestamp })
+    expect(await store.get('testKey')).toEqual({
+      value: complexTestStructure,
+      ttl: 10,
+      timestamp,
+    })
   })
 })

--- a/packages/promise-cache/src/persistor.ts
+++ b/packages/promise-cache/src/persistor.ts
@@ -1,8 +1,8 @@
 import type { UUID } from 'node:crypto'
-import type { RedisClientOptions } from 'redis'
-import { createClient } from 'redis'
-import { createLocalMemoryClient } from './localMemory'
+import { type RedisClientOptions, createClient } from 'redis'
 import type { Logger } from 'winston'
+
+import { createLocalMemoryClient } from './localMemory'
 import { deserialize, serialize } from './serializerUtils'
 
 let CACHE_CLIENT = createClient

--- a/packages/promise-cache/src/serializerUtils.ts
+++ b/packages/promise-cache/src/serializerUtils.ts
@@ -48,16 +48,22 @@ export function serialize<T>(value: T): string {
     case 'object': {
       if (Array.isArray(value)) {
         return JSON.stringify({ type: 'array', value: value.map(serialize) })
-      } else if (value instanceof Map) {
+      } 
+
+      if (value instanceof Map) {
         const entries = Array.from(value.entries()).map(([key, val]) => [
           serialize(key),
           serialize(val),
         ])
         return JSON.stringify({ type: 'map', value: entries })
-      } else if (value instanceof Set) {
+      }
+
+      if (value instanceof Set) {
         const entries = Array.from(value).map(serialize)
         return JSON.stringify({ type: 'set', value: entries })
-      } else if (value.constructor === Object) {
+      }
+
+      if (value.constructor === Object) {
         const entries = Object.entries(value).reduce(
           (acc, [key, val]) => {
             acc[key] = serialize(val)
@@ -65,10 +71,12 @@ export function serialize<T>(value: T): string {
           },
           {} as Record<string, string>
         )
+
         return JSON.stringify({ type: 'object', value: entries })
-      } else {
-        throw new Error('Cannot serialize non-plain objects')
-      }
+      } 
+
+      throw new Error('Cannot serialize non-plain objects')
+
     }
     default:
       throw new Error(`Unsupported type: ${type}`)
@@ -127,14 +135,18 @@ export function deserialize(serialized: Serialized): Serializable {
       return parsed.value.map(deserializePrimitives)
     case 'map': {
       const map = new Map<Serializable, Serializable>()
-      parsed.value.forEach(([key, val]) => {
+
+      for (const [key, val] of parsed.value) {
         map.set(deserializePrimitives(key), deserializePrimitives(val))
-      })
+      }
       return map
     }
     case 'set': {
       const set = new Set<Serializable>()
-      parsed.value.forEach((item) => set.add(deserialize(item)))
+
+      for (const item of parsed.value) {
+        set.add(deserialize(item))
+      }
       return set
     }
     case 'object': {

--- a/packages/promise-cache/src/serializerUtils.ts
+++ b/packages/promise-cache/src/serializerUtils.ts
@@ -48,7 +48,7 @@ export function serialize<T>(value: T): string {
     case 'object': {
       if (Array.isArray(value)) {
         return JSON.stringify({ type: 'array', value: value.map(serialize) })
-      } 
+      }
 
       if (value instanceof Map) {
         const entries = Array.from(value.entries()).map(([key, val]) => [
@@ -73,10 +73,9 @@ export function serialize<T>(value: T): string {
         )
 
         return JSON.stringify({ type: 'object', value: entries })
-      } 
+      }
 
       throw new Error('Cannot serialize non-plain objects')
-
     }
     default:
       throw new Error(`Unsupported type: ${type}`)
@@ -108,7 +107,9 @@ function deserializePrimitives(serialized: Serialized): Serializable {
     case 'null':
       return null
     default:
-      throw new Error(`Unsupported type during deserialization: ${parsed.type}`)
+      throw new Error(
+        `Unsupported type during deserialization: ${JSON.stringify(parsed)}`
+      )
   }
 }
 
@@ -132,12 +133,12 @@ export function deserialize(serialized: Serialized): Serializable {
     case 'null':
       return deserializePrimitives(parsed)
     case 'array':
-      return parsed.value.map(deserializePrimitives)
+      return parsed.value.map(deserialize)
     case 'map': {
       const map = new Map<Serializable, Serializable>()
 
       for (const [key, val] of parsed.value) {
-        map.set(deserializePrimitives(key), deserializePrimitives(val))
+        map.set(deserialize(key), deserialize(val))
       }
       return map
     }

--- a/packages/promise-cache/src/serializerUtils.ts
+++ b/packages/promise-cache/src/serializerUtils.ts
@@ -1,0 +1,150 @@
+type Serialized =
+  | { type: 'string'; value: string }
+  | { type: 'number'; value: number }
+  | { type: 'boolean'; value: boolean }
+  | { type: 'undefined' }
+  | { type: 'bigint'; value: string }
+  | { type: 'null' }
+  | { type: 'array'; value: Serialized[] }
+  | { type: 'map'; value: [Serialized, Serialized][] }
+  | { type: 'set'; value: Serialized[] }
+  | { type: 'object'; value: Record<string, Serialized> }
+
+type Serializable =
+  | string
+  | number
+  | boolean
+  | undefined
+  | null
+  | bigint
+  | Serializable[]
+  | Map<Serializable, Serializable>
+  | Set<Serializable>
+  | { [key: string]: Serializable }
+
+/**
+ * Serialize a value to a string.
+ * @param value Serializable
+ * @returns serialized string
+ */
+export function serialize<T>(value: T): string {
+  const type = typeof value
+
+  if (value === null) {
+    return JSON.stringify({ type: 'null' })
+  }
+
+  if (value === undefined) {
+    return JSON.stringify({ type: 'undefined' })
+  }
+
+  switch (type) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return JSON.stringify({ type, value })
+    case 'bigint':
+      return JSON.stringify({ type: 'bigint', value: value.toString() })
+    case 'object': {
+      if (Array.isArray(value)) {
+        return JSON.stringify({ type: 'array', value: value.map(serialize) })
+      } else if (value instanceof Map) {
+        const entries = Array.from(value.entries()).map(([key, val]) => [
+          serialize(key),
+          serialize(val),
+        ])
+        return JSON.stringify({ type: 'map', value: entries })
+      } else if (value instanceof Set) {
+        const entries = Array.from(value).map(serialize)
+        return JSON.stringify({ type: 'set', value: entries })
+      } else if (value.constructor === Object) {
+        const entries = Object.entries(value).reduce(
+          (acc, [key, val]) => {
+            acc[key] = serialize(val)
+            return acc
+          },
+          {} as Record<string, string>
+        )
+        return JSON.stringify({ type: 'object', value: entries })
+      } else {
+        throw new Error('Cannot serialize non-plain objects')
+      }
+    }
+    default:
+      throw new Error(`Unsupported type: ${type}`)
+  }
+}
+
+/**
+ * Deserialize primitive values from a serialized string.
+ * @param serialized The serialized primitive value.
+ * @returns The deserialized primitive value.
+ * @throws {Error} If the serialized value has an unsupported type.
+ */
+function deserializePrimitives(serialized: Serialized): Serializable {
+  let parsed: Serialized = serialized
+  if (typeof serialized === 'string') {
+    parsed = JSON.parse(serialized) as Serialized
+  }
+  switch (parsed.type) {
+    case 'string':
+      return parsed.value
+    case 'number':
+      return Number(parsed.value)
+    case 'boolean':
+      return Boolean(parsed.value)
+    case 'undefined':
+      return undefined
+    case 'bigint':
+      return BigInt(parsed.value)
+    case 'null':
+      return null
+    default:
+      throw new Error(`Unsupported type during deserialization: ${parsed.type}`)
+  }
+}
+
+/**
+ * Deserialize a value from a string.
+ * @param serialized string to deserialize
+ * @returns deserialized value
+ */
+export function deserialize(serialized: Serialized): Serializable {
+  let parsed: Serialized = serialized
+  if (typeof serialized === 'string') {
+    parsed = JSON.parse(serialized) as Serialized
+  }
+
+  switch (parsed.type) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'undefined':
+    case 'bigint':
+    case 'null':
+      return deserializePrimitives(parsed)
+    case 'array':
+      return parsed.value.map(deserializePrimitives)
+    case 'map': {
+      const map = new Map<Serializable, Serializable>()
+      parsed.value.forEach(([key, val]) => {
+        map.set(deserializePrimitives(key), deserializePrimitives(val))
+      })
+      return map
+    }
+    case 'set': {
+      const set = new Set<Serializable>()
+      parsed.value.forEach((item) => set.add(deserialize(item)))
+      return set
+    }
+    case 'object': {
+      const obj: Record<string, Serializable> = {}
+      for (const [key, val] of Object.entries(parsed.value)) {
+        obj[key] = deserialize(val)
+      }
+      return obj
+    }
+    default:
+      throw new Error(`Unsupported type during deserialization: ${parsed}`)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,7 +2879,7 @@ create-require@^1.1.0:
 
 cross-spawn@^7.0.0, cross-spawn@^7.0.3, cross-spawn@^7.0.5, cross-spawn@~7.0.6:
   version "7.0.6"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
   integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
@@ -5865,7 +5865,7 @@ secure-json-parse@^2.4.0:
 
 semver@7.6.2, semver@^5.3.0, semver@^7.0.0, semver@^7.5.2, semver@^7.5.3, semver@~7.5.4:
   version "7.5.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
@@ -7023,7 +7023,7 @@ winston@3.17.0:
 
 word-wrap@~1.2.5:
   version "1.2.5"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 wordwrap@^1.0.0:


### PR DESCRIPTION
We have some limitations
- Big Ints
- Big objects

Big int is a "big" problem, we need to transform them to string and try to store it

Big objects, node has a size limit for the string type. We can use a library like https://msgpack.org/index.html to improve performance and avoid the size error 

What do u think? shall we implement the library later? Shall we work on it now? do we need a huge improvement in performance? we still have a good performance parsing the objects to string
