### PR TITLE
Chore/add merge environments function

### DIFF
--- a/.changeset/early-actors-argue.md
+++ b/.changeset/early-actors-argue.md
@@ -1,0 +1,5 @@
+---
+"@sebspark/environment": patch
+---
+
+add mergeEnvironment helper function

--- a/packages/environment/README.md
+++ b/packages/environment/README.md
@@ -1,3 +1,71 @@
 # `@sebspark/environment`
 
-Environment
+Utilities for reading environment variables and secrets in a type-safe, lazy way.
+
+## `initEnvironment<T>()`
+
+Returns a typed proxy that reads from `process.env` on each property access. Required variables are asserted at access time — an error is thrown if the value is missing.
+
+```typescript
+import { initEnvironment } from '@sebspark/environment'
+
+type Env = {
+  API_URL: string
+  PORT: string
+}
+
+const env = initEnvironment<Env>()
+
+env.API_URL      // reads process.env.API_URL, throws if missing
+env.optional.PORT // reads process.env.PORT, returns undefined if missing
+```
+
+Values are cached after the first access.
+
+## `initSecretStore<T>(opts?)`
+
+Returns a typed proxy that reads secrets from the filesystem. Useful for Kubernetes-mounted secrets where each secret is a file named after the key.
+
+```typescript
+import { initSecretStore } from '@sebspark/environment'
+
+type Secrets = {
+  DB_PASSWORD: string
+  API_KEY: string
+}
+
+const secrets = initSecretStore<Secrets>({
+  dir: '/var/secrets',   // directory containing secret files (optional)
+  fallback: true,        // fall back to process.env if file is missing (optional)
+})
+
+secrets.DB_PASSWORD // reads /var/secrets/DB_PASSWORD
+```
+
+Options:
+
+| Option | Type | Description |
+|---|---|---|
+| `dir` | `string` | Directory to read secret files from. Defaults to CWD. |
+| `fallback` | `boolean \| Partial<T>` | If `true`, falls back to `process.env`. If an object, uses its values as fallback. |
+
+Values are cached after the first access. An error is thrown if the secret cannot be resolved.
+
+## `mergeEnvironments(env, secrets)`
+
+Merges the results of `initEnvironment` and `initSecretStore` into a single typed proxy. Secrets take precedence over environment variables for overlapping keys. Falls back to the environment proxy if a secret is not found.
+
+```typescript
+import { initEnvironment, initSecretStore, mergeEnvironments } from '@sebspark/environment'
+
+type Env = { API_URL: string; DB_PASSWORD: string }
+type Secrets = { DB_PASSWORD: string }
+
+const env = initEnvironment<Env>()
+const secrets = initSecretStore<Secrets>({ dir: '/var/secrets', fallback: true })
+
+export const Environment = mergeEnvironments(env, secrets)
+
+Environment.API_URL     // from process.env
+Environment.DB_PASSWORD // from /var/secrets/DB_PASSWORD, falls back to process.env
+```

--- a/packages/environment/src/index.spec.ts
+++ b/packages/environment/src/index.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { initEnvironment, initSecretStore } from './index'
+import { initEnvironment, initSecretStore, mergeEnvironments } from './index'
 
 describe('initEnvironment', () => {
   const originalEnv = process.env
@@ -51,6 +51,47 @@ describe('initEnvironment', () => {
     expect(env.optional.OPT_CACHED).toBe('first')
     process.env.OPT_CACHED = 'changed'
     expect(env.optional.OPT_CACHED).toBe('first')
+  })
+})
+
+describe('mergeEnvironments', () => {
+  const secretsDir = fs.mkdtempSync('/tmp/secrets-merge-')
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    for (const file of fs.readdirSync(secretsDir)) {
+      fs.unlinkSync(`${secretsDir}/${file}`)
+    }
+  })
+
+  it('reads from env when key is not in secrets', () => {
+    process.env.MY_VAR = 'from-env'
+    const env = initEnvironment<{ MY_VAR: string }>()
+    const secrets = initSecretStore<Record<never, string>>({ dir: secretsDir })
+    const merged = mergeEnvironments(env, secrets)
+    expect(merged.MY_VAR).toBe('from-env')
+  })
+
+  it('prefers secrets over env for overlapping keys', () => {
+    process.env.API_KEY = 'from-env'
+    fs.writeFileSync(`${secretsDir}/API_KEY`, 'from-secret')
+    const env = initEnvironment<{ API_KEY: string }>()
+    const secrets = initSecretStore<{ API_KEY: string }>({ dir: secretsDir })
+    const merged = mergeEnvironments(env, secrets)
+    expect(merged.API_KEY).toBe('from-secret')
+  })
+
+  it('falls back to env when secret file is missing', () => {
+    process.env.API_KEY = 'from-env'
+    const env = initEnvironment<{ API_KEY: string }>()
+    const secrets = initSecretStore<{ API_KEY: string }>({ dir: secretsDir })
+    const merged = mergeEnvironments(env, secrets)
+    expect(merged.API_KEY).toBe('from-env')
   })
 })
 

--- a/packages/environment/src/index.ts
+++ b/packages/environment/src/index.ts
@@ -38,6 +38,24 @@ export const initEnvironment = <T extends Record<string, string>>() => {
   ) as T & { optional: Partial<T> } & { [key: string]: string }
 }
 
+export const mergeEnvironments = <
+  T extends Record<string, string>,
+  U extends Record<string, string>,
+>(
+  env: T,
+  secrets: U
+): T & U =>
+  new Proxy({} as T & U, {
+    get(_, key) {
+      if (typeof key !== 'string') return undefined
+      try {
+        return (secrets as Record<string, string>)[key]
+      } catch {
+        return (env as Record<string, string>)[key]
+      }
+    },
+  })
+
 type SecretStoreOptions<T> = {
   dir?: string
   fallback?: boolean | Partial<T>


### PR DESCRIPTION
When initEnvironment and initSecretStore return Proxy objects, spreading them with { ...env, ...secrets } produces an empty object {}. This happens because JavaScript's spread operator enumerates a Proxy's own keys on the underlying target object (which is {}), rather than going through the get trap — so no values are ever read.

Function mergeEnvironments wraps both proxies in a new Proxy with a get trap that tries the secret store first and falls back to the environment, giving consumers a single merged object that behaves correctly at access time.